### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,10 +87,22 @@ jobs:
 
           cargo --version
 
+      - name: Get binstall
+        shell: bash
+        run: |
+          archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
+          wget "https://github.com/ryankurte/cargo-binstall/releases/latest/download/${archive}"
+
+          tar -xvf "./${archive}"
+
+          rm "./${archive}"
+
+          mv ./cargo-binstall ~/.cargo/bin/
+
       - name: Install cocogitto to get the next version number
         shell: bash
         run: |
-          cargo install --locked cocogitto;
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }";
 
       - name: Calculate next version
         id: version
@@ -220,15 +232,27 @@ jobs:
         run: |
           rustup component add llvm-tools-preview
 
+      - name: Get binstall
+        shell: bash
+        run: |
+          archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
+          wget "https://github.com/ryankurte/cargo-binstall/releases/latest/download/${archive}"
+
+          tar -xvf "./${archive}"
+
+          rm "./${archive}"
+
+          mv ./cargo-binstall ~/.cargo/bin/
+
       - name: Install nextest, custom test runner, with native support for junit
         shell: bash
         run: |
-          cargo install --locked cargo-nextest;
+          cargo binstall --no-confirm cargo-nextest;
 
       - name: Install grcov
         shell: bash
         run: |
-          cargo install --locked grcov;
+          cargo binstall --no-confirm grcov --pkg-url "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.bz2" --pkg-fmt tbz2 --bin-dir "{ bin }";
 
       - name: Build with instrumentation support
         shell: bash

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -44,9 +44,22 @@ jobs:
 
           cargo --version
 
-      - name: Install cocogitto for commit linting
+      - name: Get binstall
+        shell: bash
         run: |
-          cargo install --locked cocogitto;
+          archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
+          wget "https://github.com/ryankurte/cargo-binstall/releases/latest/download/${archive}"
+
+          tar -xvf "./${archive}"
+
+          rm "./${archive}"
+
+          mv ./cargo-binstall ~/.cargo/bin/
+
+      - name: Install cocogitto to get the next version number
+        shell: bash
+        run: |
+          cargo binstall --no-confirm cocogitto --pkg-url "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.tar.gz" --bin-dir "{ bin }";
 
       - name: Check the commits
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "endless-ssh-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.62.0"
 authors = ["Kristof Mattei"]
 description = "Rust end-to-end application"
 license-file = "LICENSE"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.61.0"
+channel = "stable"
 components = [ "cargo", "clippy", "rustfmt"  ]
 profile = "minimal"

--- a/update-from-upstream.sh
+++ b/update-from-upstream.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+git fetch upstream
+
+git checkout -b update-from-upstream
+git checkout update-from-upstream
+
+git merge upstream/main


### PR DESCRIPTION
- chore(deps): bump github/codeql-action from 2.1.14 to 2.1.15
- chore(deps): bump rust from 1.61.0 to 1.62.0
- feat: more rust 1.62
- chore: and more 1.62
- chore: added script to easily update from upstream
