### PR TITLE
less unsafe

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -57,7 +57,7 @@ impl Clients {
                         c.send_next = now + u128::from(config.delay_ms.get());
                         self.push_back(c);
                     },
-                    Err(()) => {
+                    Err(_) => {
                         milliseconds += c.destroy();
                     },
                 }
@@ -68,6 +68,7 @@ impl Clients {
                 );
             }
         }
+
         // TODO this is not a Rust way of returning 'no timeout'
         (-1, bytes_sent)
     }

--- a/src/ffi_wrapper.rs
+++ b/src/ffi_wrapper.rs
@@ -1,0 +1,37 @@
+use libc::c_int;
+use libc::c_void;
+use libc::setsockopt;
+use libc::socklen_t;
+use libc::SOL_SOCKET;
+use libc::SO_RCVBUF;
+use std::io::Error;
+use std::mem::size_of_val;
+use std::net::TcpStream;
+use std::os::unix::prelude::AsRawFd;
+use std::ptr::addr_of;
+
+pub(crate) fn set_receive_buffer_size(
+    tcp_stream: &TcpStream,
+    size_in_bytes: usize,
+) -> Result<(), Error> {
+    // Set the smallest possible recieve buffer. This reduces local
+    // resource usage and slows down the remote end.
+    let value: i32 = i32::try_from(size_in_bytes).expect("Byte buffer didn't fit in an i32");
+
+    #[allow(clippy::cast_possible_truncation)]
+    let r: c_int = unsafe {
+        setsockopt(
+            tcp_stream.as_raw_fd(),
+            SOL_SOCKET,
+            SO_RCVBUF,
+            addr_of!(value).cast::<c_void>(),
+            size_of_val(&value) as socklen_t,
+        )
+    };
+
+    if r == -1 {
+        return Err(Error::last_os_error());
+    }
+
+    Ok(())
+}

--- a/src/line.rs
+++ b/src/line.rs
@@ -13,7 +13,7 @@ pub(crate) fn randline(maxlen: usize) -> Vec<u8> {
     buffer[len - 2] = 13;
     buffer[len - 1] = 10;
 
-    if buffer[0..4] == [b'S', b'S', b'H', b'-'] {
+    if len > 3 && buffer[0..4] == [b'S', b'S', b'H', b'-'] {
         buffer[0] = b'X';
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod client;
 mod clients;
 mod config;
+mod ffi_wrapper;
 mod handlers;
 mod line;
 mod listener;
@@ -93,7 +94,7 @@ fn main() -> Result<(), anyhow::Error> {
                         "ACCEPT host={} port={} fd={} n={}/{}",
                         client.ipaddr,
                         client.port,
-                        client.fd.as_raw_fd(),
+                        client.tcp_stream.as_raw_fd(),
                         clients.len(),
                         config.max_clients
                     );


### PR DESCRIPTION
- feat: wrapping ffi related code
- chore: one-off fix that wasn't visible previously as we sent in a 256 length buffer, even when we consumed less
