### PR TITLE
line tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,16 +81,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
 name = "endless-ssh-rs"
 version = "0.0.0-development"
 dependencies = [
  "anyhow",
  "clap",
  "libc",
+ "mockall",
+ "mockall_double",
  "rand",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fragile"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
 name = "getrandom"
@@ -120,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +194,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mockall"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mockall_double"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae71c7bb287375187c775cf82e2dcf1bef3388aaf58f0789a77f9c7ab28466f6"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,9 +261,9 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "pin-project-lite"
@@ -163,6 +276,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -213,6 +356,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +412,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -328,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,11 @@ coverage = []
 anyhow = "1.0.58"
 clap = { version = "3.2.12", features = ["cargo"] }
 libc = "0.2.126"
+mockall = "0.11.1"
+mockall_double = "0.3.0"
 rand = "0.8.5"
 tracing = "0.1.35"
 tracing-subscriber = "0.3.14"
-# reqwest = { version = "0.11.5", features = ["json"] }
-# serde_json = "1.0.68"
-# serde = { version = "1.0.130", features = ["derive"] }
-# futures = "0.3.17"
-# tokio = { version = "1.12.0", features = ["full"] }
-# log = "0.4.14"
-# env_logger = "0.9.0"
-# serde_yaml = "0.8.21"
-# clap = { version = "3.0.14", features = ["derive"] }
 
 # We compile the Docker container with musl to get a static library. Smaller, faster.
 # BUT that means that we need to include openssl

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,13 +1,32 @@
-use rand::thread_rng;
-use rand::Rng;
+use mockall::automock;
+use mockall_double::double;
+
+#[automock]
+mod rand {
+    use rand::distributions::uniform::{SampleRange, SampleUniform};
+    use rand::Rng;
+
+    #[cfg_attr(test, allow(dead_code))]
+    pub(crate) fn rand_in_range<T, R>(range: R) -> T
+    where
+        T: SampleUniform + 'static,
+        R: SampleRange<T> + 'static,
+    {
+        ::rand::thread_rng().gen_range(range)
+    }
+}
+
+#[double]
+use self::rand as rng;
 
 pub(crate) fn randline(maxlen: usize) -> Vec<u8> {
-    let len = thread_rng().gen_range(3..=(maxlen - 2));
+    let len = rng::rand_in_range(3..=maxlen);
+    println!("Len = {}", len);
 
     let mut buffer = vec![0u8; len];
 
     for l in buffer.iter_mut().take(len - 2) {
-        *l = thread_rng().gen_range(32..=(32 + 95));
+        *l = rng::rand_in_range(32..=(32 + 95));
     }
 
     buffer[len - 2] = 13;
@@ -18,4 +37,65 @@ pub(crate) fn randline(maxlen: usize) -> Vec<u8> {
     }
 
     buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::RangeInclusive;
+
+    use crate::line::{mock_rand, randline};
+
+    #[test]
+    fn test_randline() {
+        // mock rng
+        let ctx = mock_rand::rand_in_range_context();
+
+        // set random length to requested maximum length
+        ctx.expect::<usize, RangeInclusive<usize>>()
+            .returning(|x| *x.end());
+
+        // every byte will be 66, or 'b'
+        ctx.expect::<u8, RangeInclusive<u8>>().return_const(65u8);
+
+        let max_len = 50;
+        let randline = randline(max_len);
+        assert_eq!(randline.len(), max_len);
+
+        // since we mocked the Rng, we can make sure that the line is as we expect it is
+        assert_eq!(randline[..(max_len - 2)], vec![65u8; max_len - 2]);
+
+        // do we end in a Windows linebreak?
+        assert_eq!(randline[(max_len - 2)..], [13u8, 10u8]);
+    }
+
+    #[test]
+    fn test_randline_no_ssh_prefix() {
+        // mock rng
+        let ctx = mock_rand::rand_in_range_context();
+
+        // set random length to requested maximum length
+        ctx.expect::<usize, RangeInclusive<usize>>()
+            .returning(|x| *x.end());
+
+        let fake_randoms = [b'S', b'S', b'H', b'-'];
+
+        let mut i = 0;
+
+        ctx.expect::<u8, RangeInclusive<u8>>().returning(move |_| {
+            let l = fake_randoms[i];
+            i += 1;
+            l
+        });
+
+        let max_len = 6;
+
+        let randline = randline(max_len);
+        assert_eq!(randline.len(), max_len);
+
+        let xsh = [b'X', b'S', b'H', b'-'];
+        assert_eq!(randline[..xsh.len()], xsh);
+
+        // do we end in a Windows linebreak?
+        assert_eq!(randline[(max_len - 2)..], [13u8, 10u8]);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,10 +142,3 @@ fn main() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_randline() {}
-}


### PR DESCRIPTION
- feat: wrapping ffi related code
- chore: one-off fix that wasn't visible previously as we sent in a 256 length buffer, even when we consumed less
- fix: added rand_line tests with mocks!
