### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Get binstall
         shell: bash
         run: |
+          cd /tmp
           archive="cargo-binstall-x86_64-unknown-linux-musl.tgz"
           wget "https://github.com/ryankurte/cargo-binstall/releases/latest/download/${archive}"
 
@@ -252,7 +253,7 @@ jobs:
       - name: Install grcov
         shell: bash
         run: |
-          cargo binstall --no-confirm grcov --pkg-url "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.bz2" --pkg-fmt tbz2 --bin-dir "{ bin }";
+          cargo binstall --no-confirm grcov --pkg-url "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.bz2" --pkg-fmt Tbz2 --bin-dir "{ bin }";
 
       - name: Build with instrumentation support
         shell: bash


### PR DESCRIPTION
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action digest to 8171514
- chore(deps): update actions/setup-node digest to 2a814b5
- chore(deps): update enricomi/publish-unit-test-result-action digest to 8b03530
- fix: download binstall to /tmp to avoid additional untracked files
- fix: binstall now wants stuff with a capital
