### PR TITLE
fix: formatting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -140,10 +140,10 @@ pub(crate) fn parse_cli() -> Result<Config, anyhow::Error> {
         let delay_match: Option<&u64> = matches.get_one("delay");
         if let Some(&d) = delay_match {
             let arg_u32 =
-                u32::try_from(d).with_context(|| format!("Couldn't convert '{}' to u32", d))?;
+                u32::try_from(d).with_context(|| format!("Couldn't convert '{d}' to u32"))?;
 
             let non_zero_arg = NonZeroU32::new(arg_u32)
-                .with_context(|| format!("{} is not a valid value for delay", arg_u32))?;
+                .with_context(|| format!("{arg_u32} is not a valid value for delay"))?;
 
             config.set_delay(non_zero_arg);
         }
@@ -153,10 +153,10 @@ pub(crate) fn parse_cli() -> Result<Config, anyhow::Error> {
         let port_match: Option<&u64> = matches.get_one("port");
         if let Some(&p) = port_match {
             let arg_u16 =
-                u16::try_from(p).with_context(|| format!("Couldn't convert '{}' to u16", p))?;
+                u16::try_from(p).with_context(|| format!("Couldn't convert '{p}' to u16"))?;
 
             let non_zero_arg = NonZeroU16::new(arg_u16)
-                .with_context(|| format!("{} is not a valid value for port", arg_u16))?;
+                .with_context(|| format!("{arg_u16} is not a valid value for port"))?;
 
             config.set_port(non_zero_arg);
         }
@@ -165,7 +165,7 @@ pub(crate) fn parse_cli() -> Result<Config, anyhow::Error> {
     if Some(ValueSource::CommandLine) == matches.value_source("max-line-length") {
         if let Some(&l) = matches.get_one::<u64>("max-line-length") {
             let arg_usize =
-                usize::try_from(l).with_context(|| format!("Couldn't convert '{}' to usize", l))?;
+                usize::try_from(l).with_context(|| format!("Couldn't convert '{l}' to usize"))?;
 
             let non_zero_arg = NonZeroUsize::try_from(arg_usize).map_err(|_| {
                 anyhow::Error::msg(format!(
@@ -181,7 +181,7 @@ pub(crate) fn parse_cli() -> Result<Config, anyhow::Error> {
     if Some(ValueSource::CommandLine) == matches.value_source("max-clients") {
         if let Some(&c) = matches.get_one::<u64>("max-clients") {
             let arg_usize =
-                usize::try_from(c).with_context(|| format!("Couldn't convert '{}' to usize", c))?;
+                usize::try_from(c).with_context(|| format!("Couldn't convert '{c}' to usize"))?;
 
             let non_zero_arg = NonZeroUsize::try_from(arg_usize).map_err(|_| {
                 anyhow::Error::msg(format!(

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Timeout {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Infinite => write!(f, "Infinite"),
-            Self::Duration(arg0) => write!(f, "{}", arg0),
+            Self::Duration(arg0) => write!(f, "{arg0}"),
         }
     }
 }

--- a/src/traits/display_as_debug.rs
+++ b/src/traits/display_as_debug.rs
@@ -80,7 +80,7 @@ mod tests {
 
         let only_display = (OnlyDisplay {}).display_as_debug();
 
-        assert_eq!("only_display", format!("{:?}", only_display));
+        assert_eq!("only_display", format!("{only_display:?}"));
     }
 
     #[test]

--- a/src/traits/offset_datetime_formatter.rs
+++ b/src/traits/offset_datetime_formatter.rs
@@ -8,7 +8,7 @@ pub(crate) fn offset_datetime_formatter(
     match offset_datetime.format(&Rfc3339) {
         Ok(formatted) => f.write_str(&formatted),
         Err(e) => {
-            write!(f, "Couldn't convert time to Rfc3339, error: {:?}", e)
+            write!(f, "Couldn't convert time to Rfc3339, error: {e:?}")
         },
     }
 }

--- a/src/traits/pretty_formatter.rs
+++ b/src/traits/pretty_formatter.rs
@@ -10,7 +10,7 @@ where
     E: Debug,
 {
     match t {
-        Ok(t) => write!(f, "{}", t),
-        Err(e) => write!(f, "{:?}", e),
+        Ok(t) => write!(f, "{t}"),
+        Err(e) => write!(f, "{e:?}"),
     }
 }


### PR DESCRIPTION
- fix: allow macro to be called with both StdError and anyhow::Error
- fix: formatting
