### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semantic-tags-after-release.yml
+++ b/.github/workflows/semantic-tags-after-release.yml
@@ -188,6 +188,7 @@ jobs:
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
+            type=raw,value=latest
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.0.') }}
             type=semver,pattern=v{{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}


### PR DESCRIPTION
- chore(deps): update rust:1.66.1 docker digest to b9adf48
- chore(deps): update rust:1.66.1 docker digest to 23b7815
- chore(deps): update github/codeql-action action to v2.1.38
- chore(deps): update docker/metadata-action action to v4.3.0
- chore(deps): update actions-rs-plus/clippy-check digest to 02fcef9
- chore(deps): update docker/build-push-action action to v3.3.0
- chore(deps): update returntocorp/semgrep docker digest to 855cbe1
- chore(deps): lock file maintenance
- chore(deps): update actions-rs-plus/clippy-check digest to 8440e99
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to 08a3308
- chore(deps): update actions-rs-plus/clippy-check digest to 5eb300c
- chore(deps): update github/codeql-action action to v2.1.39
- chore(deps): update returntocorp/semgrep docker digest to c842b28
- chore(deps): update returntocorp/semgrep docker digest to e497fcd
- chore(deps): update actions-rs-plus/clippy-check digest to c4cb3d7
- fix: set latest tag
- chore(deps): update actions-rs-plus/clippy-check digest to 9edbda7
- chore(deps): update actions-rs-plus/clippy-check digest to bc105ec
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to 81dead6
- chore(deps): update actions-rs-plus/clippy-check digest to 4f0f406
- chore(deps): update actions/github-script action to v6.4.0
- chore(deps): update github/codeql-action action to v2.2.0
- chore(deps): update rust to v1.67.0
- chore(deps): update github/codeql-action action to v2.2.1
- chore(deps): update returntocorp/semgrep docker digest to 4a3ac0d
- chore(deps): update docker/setup-buildx-action action to v2.3.0
- chore(deps): lock file maintenance
- chore(deps): update actions/cache action to v3.2.4
- chore(deps): update docker/setup-buildx-action action to v2.4.0
- chore(deps): update docker/build-push-action action to v3.3.1
- chore(deps): update actions-rs-plus/clippy-check digest to 9413f4a
- chore(deps): update docker/build-push-action action to v4
