### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ env:
   BUILD_DOCKER_CONTAINER: true
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
+  APPLICATION_NAME: endless-ssh-rs
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
   # just a name, but storing it separately as we're nice people
@@ -414,6 +415,8 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
         with:
+          build-args: |
+            APPLICATION_NAME=${{ env.APPLICATION_NAME }}
           context: .
           # this container is THE PR's artifact, and we will re-tag it
           # once the PR has been accepted
@@ -438,7 +441,8 @@ jobs:
       - cargo-test-and-report
       - cargo-clippy-and-report
       - docker-build
-    if: github.repository == 'kristof-mattei/endless-ssh-rs' && github.event_name == 'pull_request'
+    # Check if the event is not triggered by a fork
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request'
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -1,6 +1,7 @@
 name: Retag containers after new push / PR
 
 env:
+  BUILD_DOCKER_CONTAINER: true
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
@@ -30,9 +31,25 @@ permissions:
   packages: write
 
 jobs:
+  produce-docker-container:
+    name: Should Docker container be built?
+    runs-on: ubuntu-latest
+    outputs:
+      should: ${{ fromJSON(env.BUILD_DOCKER_CONTAINER) }}
+
+    steps:
+      - name: Dummy
+        shell: bash
+        run: |
+          echo "These are not the steps you're looking for..."
+
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-latest
+    needs:
+      - produce-docker-container
+    if: |
+      fromJSON(needs.produce-docker-container.outputs.should) == true
     steps:
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM rust:1.68.2@sha256:557ff96cf0d2bed8fe24aded88a5dabbca8d71ff4fa66b696ed8a295247c92cc as builder
 
-ENV TARGET=x86_64-unknown-linux-musl
+ARG TARGET=x86_64-unknown-linux-musl
+ARG APPLICATION_NAME
+
 RUN rustup target add ${TARGET}
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -19,23 +21,26 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 # This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
 # That means that if our dependencies don't change rebuilding is much faster
 WORKDIR /build
-RUN cargo new endless-ssh-rs
-WORKDIR /build/endless-ssh-rs
+RUN cargo new ${APPLICATION_NAME}
+WORKDIR /build/${APPLICATION_NAME}
 COPY Cargo.toml Cargo.lock ./
-RUN --mount=type=cache,id=before-build,target=/build/endless-ssh-rs/target \
+RUN --mount=type=cache,id=cargo-dependencies,target=/build/${APPLICATION_NAME}/target \
     cargo build --release --target ${TARGET}
 
 # now we copy in the source which is more prone to changes and build it
 COPY src ./src
 # --release not needed, it is implied with install
-RUN --mount=type=cache,id=after-build,target=/build/endless-ssh-rs/target \
+RUN --mount=type=cache,id=full-build,target=/build/${APPLICATION_NAME}/target \
     cargo install --path . --target ${TARGET} --root /output
 
 FROM alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
+
+ARG APPLICATION_NAME
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 WORKDIR /app
-COPY --from=builder /output/bin/endless-ssh-rs /app
-ENTRYPOINT ["/app/endless-ssh-rs"]
+COPY --from=builder /output/bin/${APPLICATION_NAME} /app/entrypoint
+
+ENTRYPOINT ["/app/entrypoint"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
+#![forbid(non_ascii_idents)]
 #![allow(clippy::uninlined_format_args)]
 
 mod cli;


### PR DESCRIPTION
- chore(deps): update npm to >=9.5.1
- chore(deps): update returntocorp/semgrep docker tag to v1.13.0
- chore(deps): update github/codeql-action action to v2.2.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.4.2
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to ^20.1.1
- chore(deps): update rust:1.67.1 docker digest to 7bbf692
- chore(deps): update rust:1.67.1 docker digest to aed98ad
- chore(deps): update returntocorp/semgrep docker tag to v1.14.0
- chore(deps): update npm to >=9.6.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to 3bef9bc
- chore(deps): lock file maintenance
- chore(deps): update node.js to >=v18.15.0
- chore(deps): update npm to >=9.6.1
- chore(deps): update actions/cache action to v3.3.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to d034d73
- chore(deps): update rust to v1.68.0
- chore(deps): update docker/setup-buildx-action action to v2.5.0
- chore(deps): update github/codeql-action action to v2.2.6
- chore(deps): update actions/cache action to v3.3.1
- chore(deps): lock file maintenance
- chore(deps): update alpine:3.17.2 docker digest to ff6bdca
- chore(deps): update npm to >=9.6.2
- chore(deps): update github/codeql-action action to v2.2.7
- chore(deps): update actions/checkout action to v3.4.0
- chore(deps): update returntocorp/semgrep docker tag to v1.15.0
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.5.0
- chore(deps): update dependency semantic-release to ^20.1.3
- chore(deps): lock file maintenance
- chore(deps): update dependency prettier to ^2.8.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.0
- chore(deps): update dependency prettier to ^2.8.6
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.1
- chore(deps): update github/codeql-action action to v2.2.8
- chore(deps): update rust:1.68.0 docker digest to e10f1e3
- chore(deps): update dependency @semantic-release/changelog to ^6.0.3
- chore(deps): update rust docker tag to v1.68.1
- chore(deps): update rust:1.68.1 docker digest to 516b408
- chore(deps): update dependency prettier to ^2.8.7
- chore(deps): update actions/checkout action to v3.5.0
- chore(deps): update dependency semantic-release to v21
- fix: ascii idents only to prevent idents starting with characters my keyboard can't handle
- feat: generalize dockerfile
- fix: allow disable container retagging
- chore(deps): update github/codeql-action action to v2.2.9
- chore(deps): update rust to v1.68.1
- fix: updated cache ids
- fix: comment indent
- fix: don't retag when we don't build a container
- chore(deps): update rust to v1.68.2
