### PR TITLE
update from upstream

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,8 +22,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "endless_ssh_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,endless_ssh_rs=trace"
             }
         },
         {
@@ -44,8 +44,8 @@
             "args": ["wrong-params"],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "endless_ssh_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,endless_ssh_rs=trace"
             }
         },
         {
@@ -66,8 +66,8 @@
             "args": ["-h"],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "endless_ssh_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,endless_ssh_rs=trace"
             }
         },
         {
@@ -89,8 +89,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "endless_ssh_rs=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,endless_ssh_rs=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"


### PR DESCRIPTION
- chore(deps): update docker/build-push-action action to v4.1.0
- chore(deps): update actions/checkout action to v3.5.3
- chore(deps): update returntocorp/semgrep docker tag to v1.26.0
- chore(deps): update rust:1.70.0 docker digest to 508253a
- chore(deps): update docker/build-push-action action to v4.1.1
- chore(deps): update dependency semantic-release to ^21.0.5
- chore(deps): update docker/metadata-action action to v4.6.0
- chore(deps): update alpine docker tag to v3.18.2
- chore(deps): update returntocorp/semgrep docker tag to v1.27.0
- chore(deps): update docker/setup-buildx-action action to v2.7.0
- chore(deps): update github/codeql-action action to v2.20.0
- chore(deps): update alpine:3.18.2 docker digest to c7431a7
- chore(deps): update alpine:3.18.2 docker digest to 5246eec
- chore(deps): update alpine:3.18.2 docker digest to 82d1e9d
- chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v1
- chore(deps): update dependency semver to ^7.5.2
- fix: also do RUST_BACKTRACE=full for debugging
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- fix: build all with tests too
