### PR TITLE
fix: no need to derive Debug

### DIFF
--- a/src/listener.rs
+++ b/src/listener.rs
@@ -10,7 +10,6 @@ use tracing::{event, Level};
 use crate::config::{BindFamily, Config};
 use crate::timeout::Timeout;
 
-#[derive(Debug)]
 pub(crate) struct Listener {
     listener: TcpListener,
     fds: pollfd,


### PR DESCRIPTION
This bug was highlighted because an update causes a transitive dependency to no longer compile `libc` with `extra_traits` (in fact, the dependency that included `libc` is completely gone).

No problem right? Except that we depend on `extra_traits` to do a `#[derive(Debug)]` on our struct, which requires `pollfd` to have `#[derive(Debug)]`.

Since that feature is now gone, `pollfd` no longer has `#[derive(Debug)]`, so our compilation fails.

One solution is to enable `extra_traits` ourselve, like doing `libc = { version = "...", features = ["extra_traits"] }` which is what I initially tried.

However, I discovered that we don't actually need `#[derive(Debug)]` on our struct.

And as such, this PR removes that `derive`.

Notice that it only showed up when doing a `cargo install` in the `Dockerfile` as a `cargo build` does not update the transitive dependencies in `Cargo.lock`. Doing a plain `cargo install` does do that unless you pass in `--locked`. We don't want to pass in `--locked` because we want to ensure we get updates of yanked packages etc.
