### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,12 +308,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@95b1a2355bd0e526ad2fd62da9fd386ad4c98474 # v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,18 +116,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -547,8 +547,8 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -562,13 +562,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -579,9 +579,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustc-demangle"
@@ -591,9 +591,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags",
  "errno",

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ mod traits;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use color_eyre::eyre;
 use time::OffsetDateTime;
 use tracing::metadata::LevelFilter;
 use tracing::{event, Level};
@@ -39,7 +38,9 @@ static RUNNING: AtomicBool = AtomicBool::new(true);
 static DUMPSTATS: AtomicBool = AtomicBool::new(false);
 
 #[allow(clippy::too_many_lines)]
-fn main() -> Result<(), eyre::Report> {
+fn main() -> Result<(), color_eyre::Report> {
+    color_eyre::install()?;
+
     env::set_var("RUST_BACKTRACE", "full");
 
     color_eyre::install().unwrap();

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- fix: trace for all, not just the app
- fix: default is to use color-eyre
- fix: trace for run and test
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to a8d4f44
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update dependency prettier to v3
- fix: add update-name script
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- fix: Coveralls as CodeCov keeps on failing
- fix: specify version, Renovate will pin it
- chore(deps): update github/codeql-action action to v2.20.4
- chore(deps): pin coverallsapp/github-action action to 95b1a23
- chore(deps): update rust to v1.71.0
- chore(deps): update returntocorp/semgrep docker tag to v1.32.0
