### PR TITLE
clippy fmt fixes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,6 @@
-use std::{
-    env,
-    ffi::OsString,
-    num::{NonZeroU16, NonZeroU32, NonZeroUsize},
-};
+use std::env;
+use std::ffi::OsString;
+use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
 
 use clap::parser::ValueSource;
 use clap::{command, value_parser, Arg, ArgAction, Command};
@@ -167,7 +165,9 @@ where
     T: Clone + Send + Sync + 'static,
 {
     // our CLI has defaults, so we check if the user has provided a value
-    let Some(ValueSource::CommandLine) = matches.value_source(key) else { return None; };
+    let Some(ValueSource::CommandLine) = matches.value_source(key) else {
+        return None;
+    };
 
     // NOTE: we might change this later to always use the user's input, as we might want this module
     // to drive the config's defaults.
@@ -187,9 +187,8 @@ mod tests {
 
     use color_eyre::eyre;
 
-    use crate::config::{BindFamily, Config};
-
     use super::parse_cli_from;
+    use crate::config::{BindFamily, Config};
 
     fn parse_factory(input: &'static str) -> Result<Config, eyre::Report> {
         // fake input

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,7 @@ impl std::fmt::Debug for Client {
             .field("bytes_sent", &self.bytes_sent)
             .field("addr", &self.addr)
             // .field("tcp_stream", &self.tcp_stream)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,6 +1,7 @@
 use ::rand::distributions::uniform::{SampleRange, SampleUniform};
 use mockall::automock;
-use rand::{rngs::ThreadRng, Rng};
+use rand::rngs::ThreadRng;
+use rand::Rng;
 
 #[automock]
 trait GetRandom {
@@ -67,7 +68,6 @@ mod tests {
     use mockall_double::double;
 
     use crate::line::randline_from;
-
     #[double]
     use crate::line::GetRandom;
 


### PR DESCRIPTION
- fix: cargo fmt for rust 1.72.0
- fix: ensure we convey that we know we don't report all fields
