### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@b7bf0a3ed3ecfa44160715d7c442788f65f0f923 # v3.23.2
+        uses: github/codeql-action/upload-sarif@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
         with:
           sarif_file: semgrep.sarif

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         },
         {
             "type": "lldb",
@@ -48,6 +49,7 @@
                 "RUST_BACKTRACE": "full",
                 "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
             },
+            "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         },
         {
@@ -71,6 +73,7 @@
                 "RUST_BACKTRACE": "full",
                 "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
             },
+            "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         },
         {
@@ -95,7 +98,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         },
         {
             "type": "lldb",
@@ -119,7 +123,8 @@
                 "RUST_BACKTRACE": "1",
                 "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
             },
-            "terminal": "integrated"
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
-    }
+    },
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.debug.engineSettings": {
+        "lldb": {
+            "internalConsoleOptions": "openOnSessionStart",
+            "terminal": "console"
+        }
+    },
+    "debug.internalConsoleOptions": "openOnSessionStart"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75.0@sha256:e1730890f6646c5d896cc6867c064fc986b6160f362f3cac7fe425c94ccbd8f2 as builder
+FROM rust:1.75.0@sha256:fb477b5dff4e71ed2f93c287926811bdffde1cfd84f67c06431ef2a884090543 as builder
 
 ARG TARGET=x86_64-unknown-linux-musl
 ARG APPLICATION_NAME


### PR DESCRIPTION
- chore(deps): update rust:1.75.0 docker digest to 2176747
- chore(deps): update rust:1.75.0 docker digest to 166aa82
- chore(deps): update rust:1.75.0 docker digest to ac8c4cb
- chore(deps): update returntocorp/semgrep docker tag to v1.57.0
- chore(deps): update actions/upload-artifact action to v4.2.0
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.58.0
- chore(deps): update actions/upload-artifact action to v4.3.0
- chore(deps): update dorny/paths-filter action to v2.12.0
- chore(deps): update npm to >=10.4.0
- chore(deps): update dorny/paths-filter action to v3
- chore(deps): update github/codeql-action action to v3.23.2
- chore(deps): update alpine docker tag to v3.19.1
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.59.0
- chore(deps): update docker/metadata-action action to v5.5.1
- chore(deps): update rust:1.75.0 docker digest to 503aee4
- chore(deps): update rust:1.75.0 docker digest to e173089
- chore(deps): update rust:1.75.0 docker digest to fb477b5
- chore(deps): update returntocorp/semgrep docker tag to v1.59.1
- chore(deps): update github/codeql-action action to v3.24.0
- chore: use internal console, not the terminal for debugging
