### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -83,7 +83,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 0
@@ -161,7 +161,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -205,7 +205,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -247,7 +247,7 @@ jobs:
     if: fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -359,7 +359,7 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
@@ -403,7 +403,7 @@ jobs:
       APPLICATION_NAME: PLACEHOLDER # overridden in step 'Set application name', this is merely to satisfy the linter
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 0

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,8 +14,8 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -55,7 +55,7 @@ jobs:
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
           fetch-depth: 2

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -42,8 +42,8 @@ jobs:
     if: |
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -22,29 +22,19 @@ jobs:
       image: returntocorp/semgrep:1.66.0@sha256:2fd35fa409f209e0fea0c2d72cf1e5b801a607959a93b13d04822bb3b6a9dfe4
 
     steps:
-      - name: Check out repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 
       - name: Run semgrep
-        shell: bash
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
         run: |
           semgrep ci --sarif --output=semgrep.sarif
 
-      - name: Fixup semgrep.sarif's startColumn==0 and/or endColumn==0
-        shell: bash
-        run: |
-          jq '.' semgrep.sarif > normalized.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.startColumn==0) | .startColumn)' normalized.sarif > fixed_start_column.sarif
-          jq 'del(.runs[].results[].locations[].physicalLocation.region | select(.endColumn==0) | .endColumn)' fixed_start_column.sarif > fixed_start_end_column.sarif
-
-          diff normalized.sarif fixed_start_end_column.sarif || true
-
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
         uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
         with:
-          sarif_file: fixed_start_end_column.sarif
+          sarif_file: semgrep.sarif

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -27,7 +27,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           show-progress: false
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,14 @@
 {
-    "rust-analyzer.runnables.extraEnv": {
-        "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
-    },
-    "rust-analyzer.debug.openDebugPane": true,
+    "debug.internalConsoleOptions": "openOnSessionStart",
+    "prettier.configPath": "./.prettierrc.cjs",
     "rust-analyzer.debug.engineSettings": {
         "lldb": {
             "internalConsoleOptions": "openOnSessionStart",
             "terminal": "console"
         }
     },
-    "debug.internalConsoleOptions": "openOnSessionStart"
+    "rust-analyzer.debug.openDebugPane": true,
+    "rust-analyzer.runnables.extraEnv": {
+        "RUST_LOG": "DEBUG,endless_ssh_rs=TRACE"
+    }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "95d8e92cac0961e91dbd517496b00f7e9b92363dbe6d42c3198268323798860c"
 dependencies = [
  "addr2line",
  "cc",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "endless-ssh-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.76.0"
+rust-version = "1.77.0"
 authors = ["Kristof Mattei"]
 description = "endless-ssh-rs"
 license-file = "LICENSE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76.0@sha256:d36f9d8a9a4c76da74c8d983d0d4cb146dd2d19bb9bd60b704cdcf70ef868d3a as builder
+FROM rust:1.77.0@sha256:00e330d2e2cdada2b75e9517c8359df208b3c880c5e34cb802c120083d50af35 as builder
 
 ARG TARGET=x86_64-unknown-linux-musl
 ARG APPLICATION_NAME

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allowed-duplicate-crates = ["regex-automata", "regex-syntax"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.61.1**
- **chore(deps): update dorny/paths-filter action to v3.0.1**
- **chore(deps): update github/codeql-action action to v3.24.2**
- **chore(deps): update github/codeql-action action to v3.24.3**
- **chore(deps): update rust:1.76.0 docker digest to a71cd88**
- **chore: explicitely set prettierrc's path**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.62.0**
- **chore(deps): update rui314/setup-mold digest to 910273f**
- **chore(deps): update github/codeql-action action to v3.24.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/download-artifact action to v4.1.3**
- **chore(deps): update docker/setup-buildx-action action to v3.1.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.63.0**
- **chore: align title**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.15.1**
- **chore(deps): update npm to >=10.5.0**
- **chore(deps): update github/codeql-action action to v3.24.6**
- **chore(deps): update actions/cache action to v4.0.1**
- **chore(deps): update rui314/setup-mold digest to c9803d2**
- **chore(deps): update actions/download-artifact action to v4.1.4**
- **chore(deps): update dorny/paths-filter action to v3.0.2**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 77b7c17**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.64.0**
- **chore(deps): update docker/build-push-action action to v5.2.0**
- **chore(deps): update rui314/setup-mold digest to 65ebd6e**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.65.0**
- **chore(deps): update rust:1.76.0 docker digest to 969ca54**
- **chore(deps): update actions/checkout action to v4.1.2**
- **chore(deps): update rust:1.76.0 docker digest to 2d1630a**
- **chore(deps): update github/codeql-action action to v3.24.7**
- **chore(deps): update rust:1.76.0 docker digest to af1e799**
- **chore(deps): update rust:1.76.0 docker digest to d36f9d8**
- **chore(deps): update docker/login-action action to v3.1.0**
- **chore(deps): update docker/build-push-action action to v5.3.0**
- **chore(deps): update docker/setup-buildx-action action to v3.2.0**
- **fix(deps): update rust crate color-eyre to 0.6.3**
- **chore(deps): update dependency @semantic-release/github to v10**
- **chore(deps): update dependency semantic-release to v23.0.3**
- **chore(deps): update dependency semantic-release to v23.0.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/commit-analyzer to v12**
- **chore(deps): update dependency semantic-release to v23.0.5**
- **chore(deps): update github/codeql-action action to v3.24.8**
- **chore(deps): update actions/cache action to v4.0.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.66.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.0**
- **fix: don't set shell, not needed in semgrep container**
- **fix: separate scan and fixup, as the scan container doesn't have bash / jq anymore**
- **fix: only upload sarif file itself**
- **fix: set unpack folder, not filepath**
- **chore: checkout to satisfy the codeql tool**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.16.1**
- **chore(deps): update rust to v1.77.0**
- **chore(deps): update github/codeql-action action to v3.24.9**
- **chore: rename semgrep job to make it register with semgrep**
- **chore: use semgrep action, not container**
- **chore(deps): update returntocorp/semgrep-action digest to 713efdd**
- **chore: back to container, the action is outdated**
- **chore: add category**
- **chore: semgrep 1 job**
- **chore: fix filename**
