### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -496,7 +496,7 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ env.PLATFORM_UNIQUE_TAG }}.tar
 
       - name: Upload artifact
-        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: containers-${{ env.PLATFORM_PAIR }}
           path: /tmp/${{ env.PLATFORM_UNIQUE_TAG }}.tar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Endless ssh rs
+# Endless SSH RS
+
+A Rust rewrite of the all-popular [Endless SSH tarpit](https://github.com/skeeto/endlessh).
+
+Technologies used:
+
+-   Rust
+-   Tokio
+-   Clap (CLI)
+-   mockall & mockall_double for easier testing
+
+Releases can be found [here](https://github.com/kristof-mattei/endless-ssh-rs/releases).


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.69.0**
- **chore(deps): update github/codeql-action action to v3.25.1**
- **chore(deps): update actions/download-artifact action to v4.1.5**
- **chore(deps): update actions/upload-artifact action to v4.3.2**
- **chore(deps): update rust:1.77.2 docker digest to 5cff578**
- **chore(deps): update rust:1.77.2 docker digest to 6052afe**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/checkout action to v4.1.3**
- **chore(deps): update actions/upload-artifact action to v4.3.3**
- **chore(deps): update actions/download-artifact action to v4.1.6**
- **chore(deps): update github/codeql-action action to v3.25.2**
- **chore: readme**
