### PR TITLE
update from upstream

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -46,6 +46,7 @@ const prettierConfig = {
             },
         },
     ],
+    plugins: ["prettier-plugin-sh"],
 };
 
 module.exports = prettierConfig;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,6 @@ dependencies = [
  "libc",
  "mockall",
  "mockall_double",
- "once_cell",
  "rand",
  "time",
  "tokio",
@@ -298,9 +297,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -491,7 +490,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy 0.8.18",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -511,7 +510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
 dependencies = [
  "getrandom",
- "zerocopy 0.8.18",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -566,18 +565,18 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -797,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "utf8parse"
@@ -953,11 +952,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79386d31a42a4996e3336b0919ddb90f81112af416270cff95b5f5af22b839c2"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
 dependencies = [
- "zerocopy-derive 0.8.18",
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -973,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76331675d372f91bf8d17e13afbd5fe639200b73d01f0fc748bb059f9cca2db7"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "endless-ssh-rs"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
-edition = "2021"
-rust-version = "1.84.1"
+edition = "2024"
+rust-version = "1.85.0"
 authors = ["Kristof Mattei"]
 description = "endless-ssh-rs"
 license-file = "LICENSE"
@@ -32,22 +32,16 @@ uninlined-format-args = { level = "allow", priority = 127 }
 let_underscore_drop = { level = "deny", priority = 127 }
 non_ascii_idents = { level = "deny", priority = 127 }
 
-[profile.dev.package.backtrace]
-opt-level = 3
-
 [features]
 coverage = []
 
 [dependencies]
 clap = { version = "4.5.30", features = ["cargo"] }
-color-eyre = { git = "https://github.com/eyre-rs/eyre", rev = "c4ee249f7c51dc6452e8704ae8d117d90d6eeebc", features = [
-    "track-caller",
-] }
+color-eyre = { git = "https://github.com/eyre-rs/eyre", rev = "c4ee249f7c51dc6452e8704ae8d117d90d6eeebc" }
 dotenvy = "0.15.7"
 libc = "0.2.169"
 mockall = "0.13.1"
 mockall_double = "0.3.1"
-once_cell = "1.20.3"
 rand = "0.9.0"
 time = { version = "0.3.37", features = ["formatting"] }
 tokio = { version = "1.43.0", features = [
@@ -68,9 +62,6 @@ tracing-subscriber = { version = "0.3.19", features = [
 tracing-error = "0.2.1"
 tokio-util = "0.7.13"
 
-# We compile the Docker container with musl to get a static library. Smaller, faster.
-# BUT that means that we need to include openssl
-# Documentation on the syntax:
-# https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies
-[target.'cfg(all(any(target_arch="x86_64", target_arch="aarch64"), target_os="linux", target_env="musl"))'.dependencies]
+# OpenSSL for musl
+# [target.'cfg(all(any(target_arch="x86_64", target_arch="aarch64"), target_os="linux", target_env="musl"))'.dependencies]
 # openssl = { version = "0.10.36", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM --platform=${BUILDPLATFORM} rust:1.85.0@sha256:b34389eb072b83bdc55c1edc5633
 ARG APPLICATION_NAME
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
-    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+    && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 # borrowed (Ba Dum Tss!) from
 # https://github.com/pablodeymo/rust-musl-builder/blob/7a7ea3e909b1ef00c177d9eeac32d8c9d7d6a08c/Dockerfile#L48-L49
 RUN --mount=type=cache,id=apt-cache-amd64,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-amd64,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    apt-get --no-install-recommends install -y \
-    build-essential \
-    musl-dev \
-    musl-tools
+    apt-get update \
+    && apt-get --no-install-recommends install --yes \
+        build-essential \
+        musl-dev \
+        musl-tools
 
 FROM rust-base AS rust-linux-amd64
 ARG TARGET=x86_64-unknown-linux-musl
@@ -22,11 +22,11 @@ FROM rust-base AS rust-linux-arm64
 ARG TARGET=aarch64-unknown-linux-musl
 RUN --mount=type=cache,id=apt-cache-arm64,from=rust-base,source=/var/cache/apt,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-arm64,from=rust-base,source=/var/lib/apt,target=/var/lib/apt,sharing=locked \
-    dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get --no-install-recommends install -y \
-    libc6-dev-arm64-cross \
-    gcc-aarch64-linux-gnu
+    dpkg --add-architecture arm64 \
+    && apt-get update \
+    && apt-get --no-install-recommends install --yes \
+        libc6-dev-arm64-cross \
+        gcc-aarch64-linux-gnu
 
 FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
 
@@ -63,16 +63,27 @@ RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
     --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
     cargo install --path . --target ${TARGET} --root /output
 
-FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
+FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS passwd-build
+
+# setting `--system` prevents prompting for a password
+RUN addgroup --gid 900 appgroup \
+    && adduser --ingroup appgroup --uid 900 --system --shell /bin/false appuser
+
+RUN cat /etc/group | grep appuser > /tmp/group_appuser
+RUN cat /etc/passwd | grep appuser > /tmp/passwd_appuser
+
+FROM scratch
 
 ARG APPLICATION_NAME
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+COPY --from=passwd-build /tmp/group_appuser /etc/group
+COPY --from=passwd-build /tmp/passwd_appuser /etc/passwd
+
 USER appuser
 
 WORKDIR /app
 
-COPY --from=rust-build /output/bin/* /app/entrypoint
+COPY --from=rust-build /output/bin/${APPLICATION_NAME} /app/entrypoint
 
 ENV RUST_BACKTRACE=full
 ENTRYPOINT ["/app/entrypoint"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "devDependencies": {
         "@actions/tool-cache": "2.0.2",
-        "prettier": "3.5.1"
+        "prettier": "3.5.1",
+        "prettier-plugin-sh": "0.15.0"
       },
       "engines": {
         "node": ">=22.14.0",
@@ -80,6 +81,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/mvdan-sh": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/mvdan-sh/-/mvdan-sh-0.10.1.tgz",
+      "integrity": "sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/prettier": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
@@ -96,6 +104,26 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-sh": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sh/-/prettier-plugin-sh-0.15.0.tgz",
+      "integrity": "sha512-U0PikJr/yr2bzzARl43qI0mApBj0C1xdAfA04AZa6LnvIKawXHhuy2fFo6LNA7weRzGlAiNbaEFfKMFo0nZr/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mvdan-sh": "^0.10.1",
+        "sh-syntax": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.3"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -105,6 +133,29 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/sh-syntax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/sh-syntax/-/sh-syntax-0.4.2.tgz",
+      "integrity": "sha512-/l2UZ5fhGZLVZa16XQM9/Vq/hezGGbdHeVEA01uWjOL1+7Ek/gt6FquW0iKKws4a9AYPYvlz6RyVvjh3JxOteg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "It's written in Rust!",
   "main": "src/main.rs",
   "scripts": {
-    "format": "prettier --write .",
-    "release": "semantic-release"
+    "format": "prettier --write ."
   },
   "engines": {
     "node": ">=22.14.0",
@@ -23,7 +22,8 @@
   "homepage": "https://github.com/kristof-mattei/endless-ssh-rs#readme",
   "devDependencies": {
     "@actions/tool-cache": "2.0.2",
-    "prettier": "3.5.1"
+    "prettier": "3.5.1",
+    "prettier-plugin-sh": "0.15.0"
   },
   "publishConfig": {
     "access": "restricted"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 match_block_trailing_comma = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,22 +1,23 @@
 use std::env;
 use std::ffi::OsString;
 use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
+use std::sync::LazyLock;
 
 use clap::parser::ValueSource;
-use clap::{command, value_parser, Arg, ArgAction, Command};
+use clap::{Arg, ArgAction, Command, command, value_parser};
 use color_eyre::eyre::{self, WrapErr};
-use once_cell::sync::Lazy;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 use crate::config::{
     Config, DEFAULT_DELAY_MS, DEFAULT_MAX_CLIENTS, DEFAULT_MAX_LINE_LENGTH, DEFAULT_PORT,
 };
 
-static DEFAULT_PORT_VALUE: Lazy<String> = Lazy::new(|| DEFAULT_PORT.to_string());
-static DEFAULT_MAX_CLIENTS_VALUE: Lazy<String> = Lazy::new(|| DEFAULT_MAX_CLIENTS.to_string());
-static DEFAULT_DELAY_MS_VALUE: Lazy<String> = Lazy::new(|| DEFAULT_DELAY_MS.to_string());
-static DEFAULT_MAX_LINE_LENGTH_VALUE: Lazy<String> =
-    Lazy::new(|| DEFAULT_MAX_LINE_LENGTH.to_string());
+static DEFAULT_PORT_VALUE: LazyLock<String> = LazyLock::new(|| DEFAULT_PORT.to_string());
+static DEFAULT_MAX_CLIENTS_VALUE: LazyLock<String> =
+    LazyLock::new(|| DEFAULT_MAX_CLIENTS.to_string());
+static DEFAULT_DELAY_MS_VALUE: LazyLock<String> = LazyLock::new(|| DEFAULT_DELAY_MS.to_string());
+static DEFAULT_MAX_LINE_LENGTH_VALUE: LazyLock<String> =
+    LazyLock::new(|| DEFAULT_MAX_LINE_LENGTH.to_string());
 
 fn build_clap_matcher() -> Command {
     command!()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use time::{Duration, OffsetDateTime};
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 pub(crate) struct Client<S> {
     pub(crate) time_spent: Duration,

--- a/src/client_queue.rs
+++ b/src/client_queue.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 use crate::client::Client;
 use crate::config::Config;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
 use std::time::Duration;
 
-use tracing::{event, Level};
+use tracing::{Level, event};
 
-pub(crate) const DEFAULT_PORT: NonZeroU16 = unsafe { NonZeroU16::new_unchecked(2223) };
-pub(crate) const DEFAULT_DELAY_MS: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(10000) };
-pub(crate) const DEFAULT_MAX_LINE_LENGTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
-pub(crate) const DEFAULT_MAX_CLIENTS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(64) };
+pub(crate) const DEFAULT_PORT: NonZeroU16 = NonZeroU16::new(2223).unwrap();
+pub(crate) const DEFAULT_DELAY_MS: NonZeroU32 = NonZeroU32::new(10000).unwrap();
+pub(crate) const DEFAULT_MAX_LINE_LENGTH: NonZeroUsize = NonZeroUsize::new(32).unwrap();
+pub(crate) const DEFAULT_MAX_CLIENTS: NonZeroUsize = NonZeroUsize::new(64).unwrap();
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Config {

--- a/src/ffi_wrapper.rs
+++ b/src/ffi_wrapper.rs
@@ -1,10 +1,10 @@
 use std::io::Error;
-use std::mem::{size_of_val, MaybeUninit};
+use std::mem::{MaybeUninit, size_of_val};
 use std::os::unix::prelude::AsRawFd;
 use std::ptr::{addr_of, null_mut};
 
 use color_eyre::eyre;
-use libc::{c_int, c_void, setsockopt, sigaction, sigset_t, socklen_t, SOL_SOCKET, SO_RCVBUF};
+use libc::{SO_RCVBUF, SOL_SOCKET, c_int, c_void, setsockopt, sigaction, sigset_t, socklen_t};
 use tokio::net::TcpStream;
 use tracing::Level;
 

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,7 +1,7 @@
 use ::rand::distr::uniform::{SampleRange, SampleUniform};
 use mockall::automock;
-use rand::rngs::ThreadRng;
 use rand::Rng;
+use rand::rngs::ThreadRng;
 
 #[automock]
 trait GetRandom {
@@ -62,9 +62,9 @@ mod tests {
 
     use mockall_double::double;
 
-    use crate::line::randline_from;
     #[double]
     use crate::line::GetRandom;
+    use crate::line::randline_from;
 
     #[test]
     fn test_randline() {

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -6,13 +6,13 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{RwLock, Semaphore, TryAcquireError};
 use tokio_util::sync::CancellationToken;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
+use crate::SIZE_IN_BYTES;
 use crate::client::Client;
 use crate::config::{BindFamily, Config};
 use crate::ffi_wrapper::set_receive_buffer_size;
 use crate::statistics::Statistics;
-use crate::SIZE_IN_BYTES;
 
 struct Listener<'c> {
     config: &'c Config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,10 @@ use tokio::net::TcpStream;
 use tokio::sync::{RwLock, Semaphore};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-use tracing::{event, Level};
+use tracing::{Level, event};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
 
 use crate::cli::parse_cli;
 use crate::statistics::Statistics;

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,6 +1,6 @@
 use std::io::ErrorKind;
 
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 use crate::line::randline;
 

--- a/src/signal_handlers.rs
+++ b/src/signal_handlers.rs
@@ -1,4 +1,4 @@
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 
 /// Waits forever for a SIGTERM
 pub(crate) async fn wait_for_sigterm() -> Option<()> {

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,5 +1,5 @@
 use time::Duration;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 use crate::client::Client;
 

--- a/src/traits/offset_datetime_formatter.rs
+++ b/src/traits/offset_datetime_formatter.rs
@@ -1,5 +1,5 @@
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 #[allow(unused)]
 pub(crate) fn offset_datetime_formatter(


### PR DESCRIPTION
- **chore(deps): update rust to v1.83.0**
- **chore(deps): update rust docker tag to v1.84.1**
- **chore(deps): update rust to v1.84.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update rust:1.84.1 docker digest to 4ac764e**
- **fix: build container from scratch**
- **chore(deps): update codecov/test-results-action action to v1.0.3**
- **chore(deps): update returntocorp/semgrep docker tag to v1.107.0**
- **chore(deps): update rust:1.84.1 docker digest to 8e112a6**
- **chore(deps): update rust:1.84.1 docker digest to 738ae99**
- **chore(deps): update docker/setup-buildx-action action to v3.9.0**
- **chore(deps): update github/codeql-action action to v3.28.9**
- **chore(deps): update dependency prettier to v3.5.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update node.js to v22.14.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.108.0**
- **chore(deps): update dependency prettier to v3.5.1**
- **chore(deps): update alpine docker tag to v3.21.3**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/cache action to v4.2.1**
- **chore(deps): update docker/build-push-action action to v6.14.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.109.0**
- **chore(deps): update codecov/test-results-action action to v1.0.4**
- **chore(deps): update actions-rs-plus/clippy-check action to v2.2.1**
- **chore: format dockerfile**
- **chore: fmt also 1.85.0**
- **chore(deps): update rust docker tag to v1.85.0**
