### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,8 @@ jobs:
         with:
           check_name: Test results
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          junit_files: reports/results.xml
+          files: |
+            reports/results.xml
 
       - name: Run grcov
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean \
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
     apt-get update \
-    && apt-get --no-install-recommends install --yes \
+    && apt-get upgrade --yes \
+    && apt-get install --no-install-recommends --yes \
         build-essential \
         musl-dev \
         musl-tools

--- a/update-from-upstream.sh
+++ b/update-from-upstream.sh
@@ -17,7 +17,7 @@ git checkout -b update-from-upstream origin/main
 git push --set-upstream origin update-from-upstream
 
 # merge in the changes from upstream
-git merge upstream/main
+git merge upstream/main --no-edit
 
 # fix stuff and ...
 # git push


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **chore(deps): update softprops/action-gh-release action to v2.3.0**
- **chore(deps): update softprops/action-gh-release action to v2.3.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.124.1**
- **chore(deps): update rust:1.87.0 docker digest to b571d7b**
- **chore: upgrade before installing**
- **chore: fix deprecation warning**
- **chore: don't prompt to accept commit when no conflicts**
