### PR TITLE
update from upstream

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -23,6 +23,7 @@ disallowed-names = ["bar", "baz", "e", "err", "foo", "ok", "quux"]
 disallowed-types = [
     { path = "std::collections::HashMap", replacement = "hashbrown::HashMap", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
     { path = "std::collections::HashSet", replacement = "hashbrown::HashSet", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
+    { path = "time::Duration", replacement = "time::SignedDuration", reason = "time::Duration is deprecated" },
 ]
 enforced-import-renames = [
     { path = "serde_json::from_slice", rename = "from_json_slice" },

--- a/clippy.toml
+++ b/clippy.toml
@@ -30,6 +30,7 @@ disallowed-names = ["bar", "baz", "e", "err", "foo", "ok", "quux"]
 disallowed-types = [
     { path = "std::collections::HashMap", replacement = "hashbrown::HashMap", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
     { path = "std::collections::HashSet", replacement = "hashbrown::HashSet", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
+    { path = "time::Duration", replacement = "time::SignedDuration", reason = "time::Duration is deprecated" },
 ]
 enforced-import-renames = [
     { path = "serde_json::from_slice", rename = "from_json_slice" },

--- a/crates/endless-ssh-rs/src/client.rs
+++ b/crates/endless-ssh-rs/src/client.rs
@@ -1,12 +1,12 @@
 use std::net::SocketAddr;
 
-use time::Duration;
+use time::SignedDuration;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::time::Instant;
 use tracing::{Level, event};
 
 pub struct Client<S> {
-    time_spent: Duration,
+    time_spent: SignedDuration,
     send_next: Instant,
     bytes_sent: usize,
     addr: SocketAddr,
@@ -55,7 +55,7 @@ impl<S> Client<S> {
         permit: OwnedSemaphorePermit,
     ) -> Self {
         Self {
-            time_spent: Duration::ZERO,
+            time_spent: SignedDuration::ZERO,
             send_next: start_sending_at,
             addr,
             bytes_sent: 0,
@@ -65,11 +65,11 @@ impl<S> Client<S> {
     }
 
     #[expect(unused, reason = "Consistency with other props")]
-    pub fn time_spent(&self) -> Duration {
+    pub fn time_spent(&self) -> SignedDuration {
         self.time_spent
     }
 
-    pub fn time_spent_mut(&mut self) -> &mut Duration {
+    pub fn time_spent_mut(&mut self) -> &mut SignedDuration {
         &mut self.time_spent
     }
 

--- a/crates/endless-ssh-rs/src/statistics.rs
+++ b/crates/endless-ssh-rs/src/statistics.rs
@@ -1,4 +1,4 @@
-use time::Duration;
+use time::SignedDuration;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -23,7 +23,7 @@ pub struct Statistics {
     pub connects: u64,
     pub lost_clients: u64,
     pub processed_clients: u64,
-    pub time_spent: Duration,
+    pub time_spent: SignedDuration,
 }
 
 impl Statistics {
@@ -38,7 +38,7 @@ impl Statistics {
                 connects: 0,
                 lost_clients: 0,
                 processed_clients: 0,
-                time_spent: Duration::ZERO,
+                time_spent: SignedDuration::ZERO,
             };
 
             loop {

--- a/crates/endless-ssh-rs/src/timeout.rs
+++ b/crates/endless-ssh-rs/src/timeout.rs
@@ -1,11 +1,11 @@
 use std::fmt::Display;
 
 use libc::timespec;
-use time::Duration;
+use time::SignedDuration;
 
 pub enum Timeout {
     Infinite,
-    Duration(Duration),
+    Duration(SignedDuration),
 }
 
 impl std::fmt::Debug for Timeout {
@@ -47,8 +47,8 @@ impl Display for Timeout {
     }
 }
 
-impl From<Option<Duration>> for Timeout {
-    fn from(duration: Option<Duration>) -> Self {
+impl From<Option<SignedDuration>> for Timeout {
+    fn from(duration: Option<SignedDuration>) -> Self {
         match duration {
             None => Timeout::Infinite,
             Some(d) => Timeout::Duration(d),

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce",
     "engines": {
-        "node": "26.5.1",
+        "node": "26.6.0",
         "pnpm": "11.19.0"
     },
     "scripts": {


### PR DESCRIPTION
- **chore(deps): update node.js to v26.6.0**
- **chore: ban `time::Duration`, it's deprecated**
- **chore: ban `time::Duration`, it's deprecated**
- **chore: ban `time::Duration`, it's deprecated**
